### PR TITLE
Java 7 is not only recommended, but required

### DIFF
--- a/download/index.md
+++ b/download/index.md
@@ -17,7 +17,7 @@ title: Downloads
 
 <small>
 **Hint:**
-You will need a Java runtime environment (JRE) to use Overture (Java SE 7 or greater is recommended). All downloads are provided under the terms and conditions of the Eclipse Foundation Software User Agreement unless otherwise specified.
+You will need a Java runtime environment (JRE) to use Overture (Java SE 7 or greater is required). All downloads are provided under the terms and conditions of the Eclipse Foundation Software User Agreement unless otherwise specified.
 </small>
 
 ### Release History


### PR DESCRIPTION
Trying to run Overture with JAVA_HOME not properly set yielded:
> Incompatible JVM:
> Version 1.6.0_36 of the JVM is not suitable for this product. Version: 1.7 or greater is required.